### PR TITLE
Add Open Graph and Twitter meta tags

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,6 +49,14 @@
     />
 
     <title><%= htmlWebpackPlugin.options.title %></title>
+    <meta property="og:title" content="Portafolio de Yeiler Simons" />
+    <meta property="og:description" content="Desarrollador de software." />
+    <meta property="og:image" content="/img/imagen_mia_768.webp" />
+    <meta property="og:url" content="https://yeilerdeveloment.site" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Portafolio de Yeiler Simons" />
+    <meta name="twitter:description" content="Desarrollador de software." />
+    <meta name="twitter:image" content="/img/imagen_mia_768.webp" />
   </head>
   <body>
     <noscript>


### PR DESCRIPTION
## Summary
- add Open Graph meta tags in `public/index.html`
- add Twitter card meta tags in `public/index.html`

## Testing
- `npm run lint`
- `curl -I https://cards-dev.twitter.com/validator` *(fails: CONNECT tunnel failed, response 403)*
- `curl -I https://developers.facebook.com/tools/debug/` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6894ace9fa048333a775736bdee5f05f