### PR TITLE
feat: enable quasar tree shaking and lazy icon loading

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,14 @@
 module.exports = {
-  presets: [
-    '@vue/cli-plugin-babel/preset'
+  presets: ['@vue/cli-plugin-babel/preset'],
+  plugins: [
+    [
+      'import',
+      {
+        libraryName: 'quasar',
+        libraryDirectory: 'src/components',
+        camel2DashComponentName: false
+      },
+      'quasar'
+    ]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
     "@quasar/extras": "^1.17.0",
+    "@fortawesome/fontawesome-svg-core": "^6.5.2",
+    "@fortawesome/free-brands-svg-icons": "^6.5.2",
+    "@fortawesome/free-solid-svg-icons": "^6.5.2",
+    "@fortawesome/vue-fontawesome": "^3.0.3",
     "@vee-validate/zod": "^4.14.7",
     "@vueuse/head": "^2.0.0",
     "async-validator": "^4.2.5",
@@ -44,6 +48,8 @@
     "html-webpack-tags-plugin": "^3.0.2",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "babel-plugin-import": "^1.13.5",
+    "webpack-bundle-analyzer": "^4.10.1"
   }
 }

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -1,4 +1,16 @@
+const { configure } = require('quasar/wrappers')
+
 module.exports = configure(() => ({
-  components: ["QTimeline", "QTimelineEntry"],
-  boot: ["quasar"],
-}));
+  plugins: ['Dialog', 'Notify'],
+  components: [
+    'QBtn',
+    'QCard',
+    'QCardSection',
+    'QChip',
+    'QSeparator',
+    'QSlideTransition',
+    'QTimeline',
+    'QTimelineEntry'
+  ],
+  extras: ['material-icons']
+}))

--- a/src/components/shared/Header.vue
+++ b/src/components/shared/Header.vue
@@ -72,7 +72,7 @@ onMounted(() => {
             class="flex items-center px-3 py-2 border rounded text-gray-800 border-gray-400 dark:text-gray-300 dark:border-gray-600"
             @click="isMenuOpen = !isMenuOpen"
           >
-            <i class="fas fa-bars"></i>
+            <font-awesome-icon :icon="['fas','bars']" />
           </button>
           <transition name="fade">
             <ul

--- a/src/components/shared/Tecnologies.vue
+++ b/src/components/shared/Tecnologies.vue
@@ -1,19 +1,19 @@
 <script setup>
 const technologies = [
-  { name: "React", icon: "fab fa-react" },
-  { name: "Angular", icon: "fab fa-angular" },
-  { name: "Vue", icon: "fab fa-vuejs" },
-  { name: "NestJS", icon: "fas fa-server" },
-  { name: "Next.js", icon: "fas fa-code" },
-  { name: "Express", icon: "fas fa-network-wired" },
-  { name: ".NET", icon: "fas fa-laptop-code" },
-  { name: "C#", icon: "fas fa-code" },
-  { name: "Git", icon: "fab fa-git-alt" },
-  { name: "Bootstrap", icon: "fab fa-bootstrap" },
-  { name: "Tailwind", icon: "fas fa-wind" },
-  { name: "Quasar", icon: "fas fa-gem" },
-  { name: "React Native", icon: "fab fa-react" },
-];
+  { name: 'React', icon: ['fab', 'react'] },
+  { name: 'Angular', icon: ['fab', 'angular'] },
+  { name: 'Vue', icon: ['fab', 'vuejs'] },
+  { name: 'NestJS', icon: ['fas', 'server'] },
+  { name: 'Next.js', icon: ['fas', 'code'] },
+  { name: 'Express', icon: ['fas', 'network-wired'] },
+  { name: '.NET', icon: ['fas', 'laptop-code'] },
+  { name: 'C#', icon: ['fas', 'code'] },
+  { name: 'Git', icon: ['fab', 'git-alt'] },
+  { name: 'Bootstrap', icon: ['fab', 'bootstrap'] },
+  { name: 'Tailwind', icon: ['fas', 'wind'] },
+  { name: 'Quasar', icon: ['fas', 'gem'] },
+  { name: 'React Native', icon: ['fab', 'react'] }
+]
 </script>
 
 <template>
@@ -28,7 +28,7 @@ const technologies = [
           :key="tech.name"
           class="bg-gray-100 dark:bg-gray-800 rounded-2xl shadow p-3 flex flex-col items-center justify-center hover:scale-105 transition-transform"
         >
-          <i :class="tech.icon" class="text-4xl bg-gradient-to-r from-blue-500 to-teal-500 dark:from-blue-600 dark:to-teal-700 inline-block text-transparent  bg-clip-text"></i>
+          <font-awesome-icon :icon="tech.icon" class="text-4xl bg-gradient-to-r from-blue-500 to-teal-500 dark:from-blue-600 dark:to-teal-700 inline-block text-transparent bg-clip-text" />
           <span class="text-lg font-medium text-gray-700 dark:text-gray-200">
             {{ tech.name }}
           </span>

--- a/src/components/shared/networkingContact.vue
+++ b/src/components/shared/networkingContact.vue
@@ -17,7 +17,7 @@ const gmail = process.env.VUE_APP_LOCATION_GMAIL;
         rel="noopener noreferrer"
         class="text-2xl text-green-700 hover:text-green-800"
       >
-        <i class="fab fa-whatsapp"></i>
+        <font-awesome-icon :icon="['fab','whatsapp']" />
       </a>
 
       <a
@@ -26,7 +26,7 @@ const gmail = process.env.VUE_APP_LOCATION_GMAIL;
         rel="noopener noreferrer"
         class="text-2xl text-blue-600 hover:text-blue-700"
       >
-        <i class="fab fa-linkedin"></i>
+        <font-awesome-icon :icon="['fab','linkedin']" />
       </a>
 
       <a
@@ -35,14 +35,14 @@ const gmail = process.env.VUE_APP_LOCATION_GMAIL;
         rel="noopener noreferrer"
         class="text-2xl text-gray-800 hover:text-gray-600 dark:text-white dark:hover:text-gray-300"
       >
-        <i class="fab fa-github"></i>
+        <font-awesome-icon :icon="['fab','github']" />
       </a>
       <a
         :href="`maito:${gmail}`"
         target="_blank"
         class="text-2xl text-red-700 hover:text-red-800"
       >
-        <i class="fas fa-envelope"></i>
+        <font-awesome-icon :icon="['fas','envelope']" />
       </a>
     </div>
   </div>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import quasar from '@/plugins/quasar'
+import fontawesome from '@/plugins/fontawesome'
 import { createHead } from '@vueuse/head'
 import { createApp } from 'vue'
 import App from './App.vue'
@@ -9,7 +10,8 @@ const app = createApp(App)
 const head = createHead()
 
 app.use(router)
-app.use(quasar)  
+app.use(quasar)
+app.use(fontawesome)
 app.use(head)
 
 app.mount('#app')

--- a/src/plugins/fontawesome.ts
+++ b/src/plugins/fontawesome.ts
@@ -1,0 +1,53 @@
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
+import {
+  faExclamationTriangle,
+  faCheck,
+  faWindowClose,
+  faServer,
+  faCode,
+  faNetworkWired,
+  faLaptopCode,
+  faWind,
+  faGem,
+  faEnvelope,
+  faBars
+} from '@fortawesome/free-solid-svg-icons'
+import {
+  faReact,
+  faAngular,
+  faVuejs,
+  faGitAlt,
+  faBootstrap,
+  faWhatsapp,
+  faLinkedin,
+  faGithub
+} from '@fortawesome/free-brands-svg-icons'
+
+library.add(
+  faExclamationTriangle,
+  faCheck,
+  faWindowClose,
+  faServer,
+  faCode,
+  faNetworkWired,
+  faLaptopCode,
+  faWind,
+  faGem,
+  faEnvelope,
+  faBars,
+  faReact,
+  faAngular,
+  faVuejs,
+  faGitAlt,
+  faBootstrap,
+  faWhatsapp,
+  faLinkedin,
+  faGithub
+)
+
+export default {
+  install(app: any) {
+    app.component('font-awesome-icon', FontAwesomeIcon)
+  }
+}

--- a/src/plugins/quasar.ts
+++ b/src/plugins/quasar.ts
@@ -1,5 +1,4 @@
 
-import '@quasar/extras/fontawesome-v6/fontawesome-v6.css'
 import '@quasar/extras/material-icons/material-icons.css'
 import { Dialog, Notify, QBtn, QCard, QCardSection, QChip, QSeparator, QSlideTransition, QTimeline, QTimelineEntry, Quasar } from 'quasar'
 import 'quasar/dist/quasar.css'

--- a/src/views/ContactMe.vue
+++ b/src/views/ContactMe.vue
@@ -28,7 +28,7 @@ const validateForm = async () => {
       timeout: 3000,
       position: "top",
       color: "red-8",
-      icon: "fa fa-exclamation-triangle",
+      icon: 'warning',
     });
   }
   return { validated: validated, errors: validationErrors };
@@ -60,7 +60,7 @@ const sendMessage = async () => {
       timeout: 3000,
       color: "green-6",
       position: "top",
-      icon: "fa fa-check",
+      icon: 'check',
     });
     Object.assign(form, {
       name: "",
@@ -75,7 +75,7 @@ const sendMessage = async () => {
       timeout: 3000,
       color: "red-8",
       position: "top",
-      icon: "fa fa-window-close",
+      icon: 'close',
     });
   }
 };


### PR DESCRIPTION
## Summary
- configure Quasar for tree-shaking and on-demand component loading
- switch to individual Font Awesome imports and register plugin
- add babel plugin and dependencies for optimized builds

## Testing
- `pnpm lint` *(fails: Cannot find module 'babel-plugin-import')*
- `pnpm run build -- --report` *(fails: Cannot find module 'babel-plugin-import')*

------
https://chatgpt.com/codex/tasks/task_e_6894acec5b208333b253fb01e9eae8a7